### PR TITLE
Add automatic identification system

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -46,6 +46,7 @@ $antispoof_table = "spoofuser";
 
 $mediawikiWebServiceEndpoint = "https://en.wikipedia.org/w/api.php";
 $mediawikiScriptPath = "https://en.wikipedia.org/w/index.php";
+$metaWikimediaWebServiceEndpoint = "https://meta.wikimedia.org/w/api.php";
 
 // URL of the current copy of the tool.
 $baseurl = "https://accounts.wmflabs.org";
@@ -113,6 +114,9 @@ $onRegistrationNewbieCheckAge = 5184000; // Account age on Wikipedia in seconds.
 
 // Force identification to the foundation
 $forceIdentification = true;
+
+// Time to cache positive automatic identification results, as a MySQL time interval
+$identificationCacheExpiry = "1 DAY";
 
 // minimum password version
 //   0 = hashed
@@ -320,8 +324,10 @@ $siteConfiguration->setBaseUrl($baseurl)
 	->setFilePath($filepath)
 	->setDebuggingTraceEnabled($enableErrorTrace)
 	->setForceIdentification($forceIdentification)
+	->setIdentificationCacheExpiry($identificationCacheExpiry)
 	->setMediawikiScriptPath($mediawikiScriptPath)
 	->setMediawikiWebServiceEndpoint($mediawikiWebServiceEndpoint)
+	->setMetaWikimediaWebServiceEndpoint($metaWikimediaWebServiceEndpoint)
 	->setEnforceOAuth($enforceOAuth)
 	->setEmailConfirmationEnabled($enableEmailConfirm == 1)
 	->setMiserModeLimit($requestLimitShowOnly)

--- a/includes/ConsoleTasks/ClearExpiredIdentificationData.php
+++ b/includes/ConsoleTasks/ClearExpiredIdentificationData.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Waca\ConsoleTasks;
+
+use Waca\IdentificationVerifier;
+use Waca\Tasks\ConsoleTaskBase;
+
+class ClearExpiredIdentificationData extends ConsoleTaskBase
+{
+	/**
+	 * @return void
+	 */
+	public function execute()
+	{
+		IdentificationVerifier::clearExpiredCacheEntries($this->getSiteConfiguration(), $this->getDatabase());
+	}
+}

--- a/includes/DataObjects/CommunityUser.php
+++ b/includes/DataObjects/CommunityUser.php
@@ -3,6 +3,7 @@
 namespace Waca\DataObjects;
 
 use DateTime;
+use Waca\IdentificationVerifier;
 
 /**
  * User data object
@@ -204,7 +205,7 @@ class CommunityUser extends User
 		return false;
 	}
 
-	public function isIdentified()
+	public function isIdentified(IdentificationVerifier $iv)
 	{
 		return false;
 	}

--- a/includes/DataObjects/User.php
+++ b/includes/DataObjects/User.php
@@ -10,6 +10,7 @@ use Waca\AuthUtility;
 use Waca\DataObject;
 use Waca\Helpers\Interfaces\IOAuthHelper;
 use Waca\Helpers\Logger;
+use Waca\IdentificationVerifier;
 use Waca\PdoDatabase;
 use Waca\SessionAlert;
 
@@ -27,7 +28,7 @@ class User extends DataObject
 	private $lastactive = "0000-00-00 00:00:00";
 	private $forcelogout = 0;
 	private $checkuser = 0;
-	private $identified = 0;
+	private $forceidentified = null;
 	private $welcome_template = 0;
 	private $abortpref = 0;
 	private $confirmationdiff = 0;
@@ -393,7 +394,7 @@ SQL
 			$statement = $this->dbObject->prepare(<<<SQL
 				INSERT INTO `user` ( 
 					username, email, password, status, onwikiname, welcome_sig, 
-					lastactive, forcelogout, checkuser, identified, 
+					lastactive, forcelogout, checkuser, forceidentified,
 					welcome_template, abortpref, confirmationdiff, emailsig, 
 					oauthrequesttoken, oauthrequestsecret, 
 					oauthaccesstoken, oauthaccesssecret
@@ -414,7 +415,7 @@ SQL
 			$statement->bindValue(":lastactive", $this->lastactive);
 			$statement->bindValue(":forcelogout", $this->forcelogout);
 			$statement->bindValue(":checkuser", $this->checkuser);
-			$statement->bindValue(":identified", $this->identified);
+			$statement->bindValue(":forceidentified", $this->forceidentified);
 			$statement->bindValue(":welcome_template", $this->welcome_template);
 			$statement->bindValue(":abortpref", $this->abortpref);
 			$statement->bindValue(":confirmationdiff", $this->confirmationdiff);
@@ -440,7 +441,7 @@ SQL
 					password = :password, status = :status,
 					onwikiname = :onwikiname, welcome_sig = :welcome_sig, 
 					lastactive = :lastactive, forcelogout = :forcelogout, 
-					checkuser = :checkuser, identified = :identified,
+					checkuser = :checkuser, forceidentified = :forceidentified,
 					welcome_template = :welcome_template, abortpref = :abortpref, 
 					confirmationdiff = :confirmationdiff, emailsig = :emailsig, 
 					oauthrequesttoken = :ort, oauthrequestsecret = :ors, 
@@ -459,7 +460,7 @@ SQL
 			$statement->bindValue(":lastactive", $this->lastactive);
 			$statement->bindValue(":forcelogout", $this->forcelogout);
 			$statement->bindValue(":checkuser", $this->checkuser);
-			$statement->bindValue(":identified", $this->identified);
+			$statement->bindValue(":forceidentified", $this->forceidentified);
 			$statement->bindValue(":welcome_template", $this->welcome_template);
 			$statement->bindValue(":abortpref", $this->abortpref);
 			$statement->bindValue(":confirmationdiff", $this->confirmationdiff);
@@ -929,12 +930,22 @@ SQL
 
 	/**
 	 * Tests if the user is identified
+	 * @param IdentificationVerifier $iv
 	 * @return bool
 	 * @category Security-Critical
 	 */
-	public function isIdentified()
+	public function isIdentified(IdentificationVerifier $iv)
 	{
-		return $this->identified === 1;
+		if ($this->forceidentified === 0 || $this->forceidentified === "0") {
+			// User forced to unidentified in the database.
+			return false;
+		} elseif ($this->forceidentified === 1 || $this->forceidentified === "1") {
+			// User forced to identified in the database.
+			return true;
+		} else {
+			// User not forced to any particular identified status; consult IdentificationVerifier
+			return $iv->isUserIdentified($this->getOnWikiName());
+		}
 	}
 
 	/**

--- a/includes/DataObjects/User.php
+++ b/includes/DataObjects/User.php
@@ -932,6 +932,9 @@ SQL
 	 * Tests if the user is identified
 	 * @param IdentificationVerifier $iv
 	 * @return bool
+	 * @todo Figure out what on earth is going on with PDO's typecasting here.  Apparently, it returns string("0") for
+	 *       the force-unidentified case, and int(1) for the identified case?!  This is quite ugly, but probably needed
+	 *       to play it safe for now.
 	 * @category Security-Critical
 	 */
 	public function isIdentified(IdentificationVerifier $iv)

--- a/includes/IdentificationVerifier.php
+++ b/includes/IdentificationVerifier.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Waca;
+
+use PDO;
+
+use Waca\Helpers\HttpHelper;
+
+/**
+ * Class IdentificationVerifier
+ *
+ * Handles automatically verifying if users are identified with the Wikimedia Foundation or not.  Intended to be used
+ * as necessary by the User class when a user's "forceidentified" attribute is NULL.
+ *
+ * @package Waca
+ * @author Andrew "FastLizard4" Adams
+ * @category Security-Critical
+ */
+class IdentificationVerifier
+{
+	/**
+	 * This field is an array of parameters, in key => value format, that should be appended to the Meta Wikimedia
+	 * Web Service Endpoint URL to query if a user is listed on the Identification Noticeboard.  Note that URL encoding
+	 * of these values is *not* necessary; this is done automatically.
+	 *
+	 * @var string[]
+	 * @category Security-Critical
+	 */
+	private static $apiQueryParameters = array(
+		'action'   => 'query'                                             ,
+		'format'   => 'json'                                              ,
+		'prop'     => 'links'                                             ,
+		'titles'   => 'Access to nonpublic information policy/Noticeboard',
+		'pltitles' => '' // Username of the user to be checked, with User: prefix, goes here!  Set in isIdentifiedOnWiki()
+	);
+
+	/** @var HttpHelper */
+	private $httpHelper;
+	/** @var SiteConfiguration */
+	private $siteConfiguration;
+	/** @var PdoDatabase */
+	private $dbObject;
+
+	/**
+	 * IdentificationVerifier constructor.
+	 *
+	 * @param HttpHelper $httpHelper
+	 * @param SiteConfiguration $siteConfiguration
+	 * @param PdoDatabase $dbObject
+	 */
+	public function __construct(HttpHelper $httpHelper, SiteConfiguration $siteConfiguration, PdoDatabase $dbObject)
+	{
+		$this->httpHelper = $httpHelper;
+		$this->siteConfiguration = $siteConfiguration;
+		$this->dbObject = $dbObject;
+	}
+
+	/**
+	 * Checks if the given user is identified to the Wikimedia Foundation.
+	 *
+	 * @param string $onwikiname The Wikipedia username of the user
+	 * @return bool
+	 * @category Security-Critical
+	 */
+	public function isUserIdentified($onwikiname)
+	{
+		if ($this->checkIdentificationCache($onwikiname)) {
+			return true;
+		} else {
+			if ($this->isIdentifiedOnWiki($onwikiname)) {
+				$this->cacheIdentificationStatus($onwikiname);
+				return true;
+			} else {
+				return false;
+			}
+		}
+	}
+
+	/**
+	 * Checks if the given user has a valid entry in the idcache table.
+	 *
+	 * @param string $onwikiname The Wikipedia username of the user
+	 * @return bool
+	 * @category Security-Critical
+	 */
+	private function checkIdentificationCache($onwikiname) {
+		$query = <<<SQL
+			SELECT COUNT(`id`)
+			FROM `idcache`
+			WHERE `onwikiusername` = :onwikiname
+				AND DATE_ADD(`checktime`, INTERVAL {$this->siteConfiguration->getIdentificationCacheExpiry()}) >= NOW();
+SQL;
+		$stmt = $this->dbObject->prepare($query);
+		$stmt->bindValue(':onwikiname', $onwikiname, PDO::PARAM_STR);
+		$stmt->execute();
+
+		// Guaranteed by the query to only return a single row with a single column
+		$results = $stmt->fetch(PDO::FETCH_NUM);
+
+		// I don't expect this to ever be a value other than 0 or 1 since the `onwikiusername` column is declared as a
+		// unique key - but meh.
+		return $results[0] != 0;
+	}
+
+	/**
+	 * Does pretty much exactly what it says on the label - this method will clear all expired idcache entries from the
+	 * idcache table.  Meant to be called periodically by a maintenance script.
+	 *
+	 * @param SiteConfiguration $siteConfiguration
+	 * @param PdoDatabase $dbObject
+	 * @return void
+	 */
+	public static function clearExpiredCacheEntries(SiteConfiguration $siteConfiguration, PdoDatabase $dbObject) {
+		$query = <<<SQL
+			DELETE FROM `idcache`
+			WHERE DATE_ADD(`checktime`, INTERVAL {$siteConfiguration->getIdentificationCacheExpiry()}) < NOW();
+SQL;
+		$dbObject->prepare($query)->execute();
+	}
+
+	/**
+	 * This method will add an entry to the idcache that the given Wikipedia user has been verified as identified.  This
+	 * is so we don't have to hit the API every single time we check.  The cache entry is valid for as long as specified
+	 * in the ACC configuration (validity enforced by checkIdentificationCache() and clearExpiredCacheEntries()).
+	 *
+	 * @param string $onwikiname The Wikipedia username of the user
+	 * @return void
+	 * @category Security-Critical
+	 */
+	private function cacheIdentificationStatus($onwikiname) {
+		$query = <<<SQL
+			INSERT INTO `idcache`
+				(`onwikiusername`)
+			VALUES
+				(:onwikiname)
+			ON DUPLICATE KEY UPDATE
+				`onwikiusername` = VALUES(`onwikiusername`),
+				`checktime` = CURRENT_TIMESTAMP;
+SQL;
+		$stmt = $this->dbObject->prepare($query);
+		$stmt->bindValue(':onwikiname', $onwikiname, PDO::PARAM_STR);
+		$stmt->execute();
+	}
+
+	/**
+	 * Queries the Wikimedia API to determine if the specified user is listed on the identification noticeboard.
+	 *
+	 * @param string $onwikiname The Wikipedia username of the user
+	 * @return bool
+	 * @category Security-Critical
+	 */
+	private function isIdentifiedOnWiki($onwikiname) {
+		$parameters = self::$apiQueryParameters;
+		$parameters['pltitles'] = "User:" . $onwikiname;
+		$response = $this->httpHelper->get($this->siteConfiguration->getMetaWikimediaWebServiceEndpoint(), $parameters);
+		$response = json_decode($response, true);
+
+		// Eww.  I hope the page ID never changes....
+		return @$response['query']['pages']['8644848']['links'][0]['title'] === "User:" . $onwikiname;
+	}
+}

--- a/includes/SecurityConfiguration.php
+++ b/includes/SecurityConfiguration.php
@@ -140,15 +140,16 @@ final class SecurityConfiguration
 	 * that a user should have access to something.
 	 *
 	 * @param User $user
+	 * @param IdentificationVerifier $iv
 	 *
 	 * @return bool
 	 * @category Security-Critical
 	 */
-	public function allows(User $user)
+	public function allows(User $user, IdentificationVerifier $iv)
 	{
 		$allowed = false;
 
-		if ($this->requireIdentified && !$user->isCommunityUser() && !$user->isIdentified()) {
+		if ($this->requireIdentified && !$user->isCommunityUser() && !$user->isIdentified($iv)) {
 			return false;
 		}
 

--- a/includes/SiteConfiguration.php
+++ b/includes/SiteConfiguration.php
@@ -203,7 +203,8 @@ class SiteConfiguration
 	/**
 	 * @return string
 	 */
-	public function getIdentificationCacheExpiry() {
+	public function getIdentificationCacheExpiry()
+	{
 		return $this->identificationCacheExpiry;
 	}
 
@@ -211,7 +212,8 @@ class SiteConfiguration
 	 * @param string $identificationCacheExpiry
 	 * @return SiteConfiguration
 	 */
-	public function setIdentificationCacheExpiry($identificationCacheExpiry) {
+	public function setIdentificationCacheExpiry($identificationCacheExpiry)
+	{
 		$this->identificationCacheExpiry = $identificationCacheExpiry;
 		return $this;
 	}
@@ -259,7 +261,8 @@ class SiteConfiguration
 	/**
 	 * @return string
 	 */
-	public function getMetaWikimediaWebServiceEndpoint() {
+	public function getMetaWikimediaWebServiceEndpoint()
+	{
 		return $this->metaWikimediaWebServiceEndpoint;
 	}
 
@@ -267,7 +270,8 @@ class SiteConfiguration
 	 * @param string $metaWikimediaWebServiceEndpoint
 	 * @return SiteConfiguration
 	 */
-	public function setMetaWikimediaWebServiceEndpoint($metaWikimediaWebServiceEndpoint) {
+	public function setMetaWikimediaWebServiceEndpoint($metaWikimediaWebServiceEndpoint)
+	{
 		$this->metaWikimediaWebServiceEndpoint = $metaWikimediaWebServiceEndpoint;
 
 		return $this;

--- a/includes/SiteConfiguration.php
+++ b/includes/SiteConfiguration.php
@@ -13,14 +13,16 @@ class SiteConfiguration
 {
 	private $baseUrl;
 	private $filePath;
-	private $schemaVersion = 17;
+	private $schemaVersion = 18;
 	private $debuggingTraceEnabled;
 	private $dataClearIp = '127.0.0.1';
 	private $dataClearEmail = 'acc@toolserver.org';
 	private $dataClearInterval = '15 DAY';
 	private $forceIdentification = true;
+	private $identificationCacheExpiry = '1 DAY';
 	private $mediawikiScriptPath = "https://en.wikipedia.org/w/index.php";
 	private $mediawikiWebServiceEndpoint = "";
+	private $metaWikimediaWebServiceEndpoint = "https://meta.wikimedia.org/w/api.php";
 	private $enforceOAuth = true;
 	private $emailConfirmationEnabled = true;
 	private $miserModeLimit = 25;
@@ -201,6 +203,22 @@ class SiteConfiguration
 	/**
 	 * @return string
 	 */
+	public function getIdentificationCacheExpiry() {
+		return $this->identificationCacheExpiry;
+	}
+
+	/**
+	 * @param string $identificationCacheExpiry
+	 * @return SiteConfiguration
+	 */
+	public function setIdentificationCacheExpiry($identificationCacheExpiry) {
+		$this->identificationCacheExpiry = $identificationCacheExpiry;
+		return $this;
+	}
+
+	/**
+	 * @return string
+	 */
 	public function getMediawikiScriptPath()
 	{
 		return $this->mediawikiScriptPath;
@@ -234,6 +252,23 @@ class SiteConfiguration
 	public function setMediawikiWebServiceEndpoint($mediawikiWebServiceEndpoint)
 	{
 		$this->mediawikiWebServiceEndpoint = $mediawikiWebServiceEndpoint;
+
+		return $this;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getMetaWikimediaWebServiceEndpoint() {
+		return $this->metaWikimediaWebServiceEndpoint;
+	}
+
+	/**
+	 * @param string $metaWikimediaWebServiceEndpoint
+	 * @return SiteConfiguration
+	 */
+	public function setMetaWikimediaWebServiceEndpoint($metaWikimediaWebServiceEndpoint) {
+		$this->metaWikimediaWebServiceEndpoint = $metaWikimediaWebServiceEndpoint;
 
 		return $this;
 	}

--- a/includes/Tasks/ITask.php
+++ b/includes/Tasks/ITask.php
@@ -8,6 +8,7 @@ use Waca\Helpers\Interfaces\IOAuthHelper;
 use Waca\Helpers\Interfaces\ITypeAheadHelper;
 use Waca\Helpers\IrcNotificationHelper;
 use Waca\Helpers\WikiTextHelper;
+use Waca\IdentificationVerifier;
 use Waca\PdoDatabase;
 use Waca\Providers\Interfaces\IAntiSpoofProvider;
 use Waca\Providers\Interfaces\ILocationProvider;
@@ -147,4 +148,10 @@ interface ITask
 	 * @return void
 	 */
 	public function setNotificationHelper($notificationHelper);
+
+	/**
+	 * @param IdentificationVerifier $identificationVerifier
+	 * @return void
+	 */
+	public function setIdentificationVerifier(IdentificationVerifier $identificationVerifier);
 }

--- a/includes/Tasks/InternalPageBase.php
+++ b/includes/Tasks/InternalPageBase.php
@@ -14,6 +14,17 @@ abstract class InternalPageBase extends PageBase
 	private $identificationVerifier;
 
 	/**
+	 * Sets up the internal IdentificationVerifier instance.  Intended to be called from WebStart::setupHelpers().
+	 *
+	 * @param IdentificationVerifier $identificationVerifier
+	 * @return void
+	 */
+	public function setIdentificationVerifier(IdentificationVerifier $identificationVerifier)
+	{
+		$this->identificationVerifier = $identificationVerifier;
+	}
+
+	/**
 	 * Runs the page code
 	 *
 	 * @throws Exception
@@ -21,8 +32,6 @@ abstract class InternalPageBase extends PageBase
 	 */
 	final public function execute()
 	{
-		$this->identificationVerifier = new IdentificationVerifier($this->getHttpHelper(), $this->getSiteConfiguration(), $this->getDatabase());
-
 		if ($this->getRouteName() === null) {
 			throw new Exception("Request is unrouted.");
 		}

--- a/includes/Tasks/TaskBase.php
+++ b/includes/Tasks/TaskBase.php
@@ -8,6 +8,7 @@ use Waca\Helpers\Interfaces\IOAuthHelper;
 use Waca\Helpers\Interfaces\ITypeAheadHelper;
 use Waca\Helpers\IrcNotificationHelper;
 use Waca\Helpers\WikiTextHelper;
+use Waca\IdentificationVerifier;
 use Waca\PdoDatabase;
 use Waca\Providers\Interfaces\IAntiSpoofProvider;
 use Waca\Providers\Interfaces\ILocationProvider;
@@ -238,5 +239,14 @@ abstract class TaskBase implements ITask
 	final public function setSiteConfiguration($configuration)
 	{
 		$this->siteConfiguration = $configuration;
+	}
+
+	/**
+	 * @param IdentificationVerifier $identificationVerifier
+	 * @return void
+	 */
+	public function setIdentificationVerifier(IdentificationVerifier $identificationVerifier)
+	{
+		// Go nowhere, do nothing
 	}
 }

--- a/includes/WebStart.php
+++ b/includes/WebStart.php
@@ -8,6 +8,8 @@ use Waca\Exceptions\ReadableException;
 use Waca\Providers\GlobalStateProvider;
 use Waca\Router\IRequestRouter;
 use Waca\Router\RequestRouter;
+use Waca\Tasks\InternalPageBase;
+use Waca\Tasks\ITask;
 
 /**
  * Internal application entry point.
@@ -39,6 +41,24 @@ class WebStart extends ApplicationBase
 		else {
 			$this->requestRouter = $router;
 		}
+	}
+
+	/**
+	 * @param ITask             $page
+	 * @param SiteConfiguration $siteConfiguration
+	 * @param PdoDatabase       $database
+	 * @param PdoDatabase       $notificationsDatabase
+	 * @return void
+	 */
+	protected function setupHelpers(
+		ITask $page,
+		SiteConfiguration $siteConfiguration,
+		PdoDatabase $database,
+		PdoDatabase $notificationsDatabase
+	) {
+		parent::setupHelpers($page, $siteConfiguration, $database, $notificationsDatabase);
+		$identificationVerifier = new IdentificationVerifier($page->getHttpHelper(), $siteConfiguration, $database);
+		$page->setIdentificationVerifier($identificationVerifier);
 	}
 
 	/**

--- a/maintenance/ClearExpiredIdentificationData.php
+++ b/maintenance/ClearExpiredIdentificationData.php
@@ -1,0 +1,14 @@
+<?php
+namespace Waca;
+
+use Waca\ConsoleTasks\ClearExpiredIdentificationData;
+
+chdir(__DIR__);
+chdir('..');
+
+require_once('config.inc.php');
+
+global $siteConfiguration;
+$application = new ConsoleStart($siteConfiguration, new ClearExpiredIdentificationData());
+
+$application->run();

--- a/sql/patches/patch18-automatic-id-system.sql
+++ b/sql/patches/patch18-automatic-id-system.sql
@@ -1,0 +1,76 @@
+-- -----------------------------------------------------------------------------
+-- Hey!
+-- 
+-- This is a new patch-creation script which SHOULD stop double-patching and
+-- running patches out-of-order.
+--
+-- If you're running patches, please close this file, and run this from the 
+-- command line:
+--   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
+-- where:
+--      USERNAME = a user with CREATE/ALTER access to the schema
+--      SCHEMA = the schema to run the changes against
+--      patch-XX-this-file.sql = this file
+--
+-- If you are writing patches, you need to copy this template to a numbered 
+-- patch file, update the patchversion variable, and add the SQL code to upgrade
+-- the database where indicated below.
+
+DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
+DELIMITER ';;'
+CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN
+    -- -------------------------------------------------------------------------
+    -- Developers - set the number of the schema patch here!
+    -- -------------------------------------------------------------------------
+    DECLARE patchversion INT DEFAULT 18;
+    -- -------------------------------------------------------------------------
+    -- working variables
+    DECLARE currentschemaversion INT DEFAULT 0;
+    DECLARE lastversion INT;
+	
+    -- check the schema has a version table
+    IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = 'schemaversion' AND table_schema = DATABASE()) THEN
+        SIGNAL SQLSTATE '45000' SET message_text = 'Please ensure patches are run in order! This database does not have a schemaversion table.';
+    END IF;
+    
+    -- get the current version
+    SELECT version INTO currentschemaversion FROM schemaversion;
+    
+    -- check schema is not ahead of this patch
+    IF currentschemaversion >= patchversion THEN
+        SIGNAL SQLSTATE '45000' SET message_text = 'This patch has already been applied!';
+    END IF;
+    
+    -- check schema is up-to-date
+    SET lastversion = patchversion - 1;
+    IF currentschemaversion != lastversion THEN
+		SET @message_text = CONCAT('Please ensure patches are run in order! This patch upgrades to version ', patchversion, ', but the database is not version ', lastversion);
+        SIGNAL SQLSTATE '45000' SET message_text = @message_text;
+    END IF;
+
+    -- -------------------------------------------------------------------------
+    -- Developers - put your upgrade statements here!
+    -- -------------------------------------------------------------------------
+
+    ALTER TABLE `user`
+    CHANGE COLUMN `identified` `forceidentified` INT(1) UNSIGNED NULL DEFAULT NULL;
+
+    UPDATE `user`
+    SET `forceidentified` = NULL
+    WHERE `forceidentified` = 0;
+
+    CREATE TABLE `idcache` (
+        `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+        `onwikiusername` VARCHAR(255) NOT NULL,
+        `checktime` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (`id`),
+        UNIQUE KEY (`onwikiusername`)
+    ) ENGINE=InnoDB DEFAULT COLLATE=utf8_bin;
+
+    -- -------------------------------------------------------------------------
+    -- finally, update the schema version to indicate success
+    UPDATE schemaversion SET version = patchversion;
+END;;
+DELIMITER ';'
+CALL SCHEMA_UPGRADE_SCRIPT();
+DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;

--- a/tests/includes/IdentificationVerifierTest.php
+++ b/tests/includes/IdentificationVerifierTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Waca\Tests;
+
+use PHPUnit_Framework_TestCase;
+
+use Waca\Helpers\HttpHelper;
+use Waca\IdentificationVerifier;
+use Waca\PdoDatabase;
+use Waca\SiteConfiguration;
+
+/**
+ * Class IdentificationVerifierTest
+ *
+ * For now, this file will only contain a very simple unit test that ensures we're getting results we expect from the
+ * Meta Wikimedia API call.  More thorough testing will be implemented later.
+ *
+ * @package Waca\Tests
+ */
+class IdentificationVerifierTest extends PHPUnit_Framework_TestCase
+{
+	/** @var IdentificationVerifier */
+	private $identificationVerifier;
+
+	public function setUp()
+	{
+		$dummyConfiguration = new SiteConfiguration();
+		$httpHelper = new HttpHelper($dummyConfiguration->getUserAgent(), false);
+		$dummyDatabase = $this->getMockBuilder(PdoDatabase::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->identificationVerifier = new IdentificationVerifier($httpHelper, $dummyConfiguration, $dummyDatabase);
+	}
+
+	public function tearDown()
+	{
+		$this->identificationVerifier = null;
+	}
+
+	// Since this test actually queries the real Identification Noticeboard, the assertions should be periodically
+	// manually verified by a human.
+	public function testApiReturnsExpectedResults()
+	{
+		$reflector = new \ReflectionClass($this->identificationVerifier);
+		$method = $reflector->getMethod('isIdentifiedOnWiki');
+		$method->setAccessible(true);
+
+		$this->assertTrue($method->invoke($this->identificationVerifier, "Stwalkerster"));
+		$this->assertTrue($method->invoke($this->identificationVerifier, "stwalkerster"), "First character case insensitivity test failed");
+		$this->assertTrue($method->invoke($this->identificationVerifier, "FastLizard4"));
+		$this->assertFalse($method->invoke($this->identificationVerifier, "fastlizard4"), "Username case sensitivity test (for more than first character) failed");
+		$this->assertFalse($method->invoke($this->identificationVerifier, "Grawp"));
+		$this->assertFalse($method->invoke($this->identificationVerifier, "Willie On Wheels"));
+
+		// Some non-standard or non-Latin names to try out
+		$this->assertTrue($method->invoke($this->identificationVerifier, "-revi"));
+		$this->assertTrue($method->invoke($this->identificationVerifier, "555"));
+		$this->assertTrue($method->invoke($this->identificationVerifier, "Trần Nguyễn Minh Huy"));
+		$this->assertTrue($method->invoke($this->identificationVerifier, "محمد شعیب"));
+		$this->assertTrue($method->invoke($this->identificationVerifier, "יונה בנדלאק"));
+		$this->assertTrue($method->invoke($this->identificationVerifier, "和平奮鬥救地球"));
+		$this->assertFalse($method->invoke($this->identificationVerifier, "-rei"));
+		$this->assertFalse($method->invoke($this->identificationVerifier, "55"));
+		$this->assertFalse($method->invoke($this->identificationVerifier, "TrầnNguyễnMinhHuy"));
+		$this->assertFalse($method->invoke($this->identificationVerifier, "محمدشعیب"));
+		$this->assertFalse($method->invoke($this->identificationVerifier, "יונהבנדלאק"));
+		$this->assertFalse($method->invoke($this->identificationVerifier, "和平奮救地球"));
+	}
+}


### PR DESCRIPTION
These commits add an automatic identification system compatible with the newinternal rewrite.  Notably, this pull request includes a schema update that adds an identification cache table while changing the "identified" column in the user table to a "forceidentified" column.

With this pull request, the user.forceidentified column can still be set to 0 to force a user to be recognized as unidentified, or to 1 to force a user to be recognized as identified.  However, if it is instead set to the new default value of NULL, the IdenitificationVerifier class is called upon to check on demand and automatically if the user is identified or not by making an API call to Meta.  If the user is identified, the result is cached for a configurable length of time (in the aforementioned idcache table) to prevent unnecesssary overhead and API calls.

This pull request satisfies enwikipedia-acc#240, though it won't be truly resolved until the newinternal changes are also merged into the mainline (enwikipedia-acc#232).

Note that this pull request includes a simple unit test to ensure that we're getting results we expect from the API, but the test is by no means exhaustively testing IdentificationVerifier.

Finally also note that the SQL schema update included in this pull request will update everyone's identified value as following:

* If user is currently marked as identified (identified=1), they will continue to be marked as force-identified in the database (forceidentified=1)
* If a user is currently marked as unidentified (identified=0), they will be marked for automatic identification verification (forceidentified=NULL).  These checks will only occur when the user attempts to log in, though.